### PR TITLE
redownlaod-feature

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -754,6 +754,42 @@ const App: React.FC = () => {
       Haptics.notification({ type: success ? NotificationType.Success : NotificationType.Error });
   }, []);
 
+
+const handleRedownload = (app: AppItem, specificUrl?: string) => {
+    const urlToUse = specificUrl || app.downloadUrl;
+    if (!urlToUse || urlToUse === '#' || urlToUse === '') {
+        setErrorMsg('Download link not found');
+        setShowErrorToast(true);
+        setTimeout(() => setShowErrorToast(false), 3000);
+        return;
+    }
+
+    try {
+        // Remove installed version 
+        const newReg = { ...installedVersions };
+        delete newReg[app.id];
+        setInstalledVersions(newReg);
+        safeStorage.setItem('installed_apps', JSON.stringify(newReg));
+
+        // Show redownload status
+        setErrorMsg('Removing old file, Redownloading now...');
+        setShowErrorToast(true);
+
+        // Trigger redownload 
+        setTimeout(() => {
+            setShowErrorToast(false);
+            handleDownloadAction(app, urlToUse);
+        }, 1000);
+    } catch (error) {
+        console.error('Redownload error:', error);
+        setErrorMsg('Failed to redownload. Try again.');
+        setShowErrorToast(true);
+        setTimeout(() => setShowErrorToast(false), 3000);
+    }
+  };
+
+
+
   const checkForUpdates = async () => {
       if (!autoUpdateEnabled || !Capacitor.isNativePlatform() || (wifiOnly && !isWifiConnected())) return;
       const updates = appsRef.current.filter(app => {


### PR DESCRIPTION
when user loses internet connection mid download it marks the app as installed and unable to redownload the apk in any anyway. It clears internal data of the app to make the redownload possible.
Added a function to redownload the file incase the already installed file is corrupted or has any sort of problems. It

when user loses internet connection mid download it marks the app as installed and unable to redownload the apk in any anyway.

I'm a very beginner so suggest me any changes i need to improve on.